### PR TITLE
make configurable auto mappings/settings update

### DIFF
--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -73,6 +73,8 @@ ctia.store.es.default.refresh=false
 ctia.store.es.default.rollover.max_docs=10000000
 ctia.store.es.default.aliased=true
 ctia.store.es.default.version=5
+ctia.store.es.default.update-mappings=true
+ctia.store.es.default.update-settings=true
 
 ctia.store.actor=es
 ctia.store.asset=es

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -36,7 +36,9 @@
    (str prefix store ".aliased")  s/Bool
    (str prefix store ".default_operator") (s/enum "OR" "AND")
    (str prefix store ".timeout") s/Num
-   (str prefix store ".version") s/Num})
+   (str prefix store ".version") s/Num
+   (str prefix store ".update-mappings")  s/Bool
+   (str prefix store ".update-settings")  s/Bool})
 
 (s/defschema StorePropertiesSchema
   "All entity store properties for every implementation"

--- a/src/ctia/task/update_mapping.clj
+++ b/src/ctia/task/update_mapping.clj
@@ -13,12 +13,12 @@
             [schema.core :as s]))
 
 (defn- update-mapping-state!
-  [{:keys [conn index config] :as state}]
-  (run! #(% conn index config)
+  [conn-state]
+  (run! #(% conn-state)
         ; template update should go first in the (unlikely) case of
         ; a race condition with a simultaneously successful rollover.
         [es-init/upsert-template!
-         es-init/update-mapping!]))
+         es-init/update-mappings!]))
 
 (defn update-mapping-stores!
   "Takes a map the same shape as returned by ctia.store-service/all-stores

--- a/test/ctia/properties_test.clj
+++ b/test/ctia/properties_test.clj
@@ -20,6 +20,8 @@
             "ctia.store.es.malware.aliased"  s/Bool
             "ctia.store.es.malware.default_operator" (s/enum "OR" "AND")
             "ctia.store.es.malware.version" s/Num
+            "ctia.store.es.malware.update-mappings" s/Bool
+            "ctia.store.es.malware.update-settings" s/Bool
             "ctia.store.es.malware.timeout" s/Num}
            (sut/es-store-impl-properties "ctia.store.es." "malware")))
 
@@ -37,5 +39,7 @@
             "prefix.sighting.aliased"  s/Bool
             "prefix.sighting.default_operator" (s/enum "OR" "AND")
             "prefix.sighting.version" s/Num
+            "prefix.sighting.update-mappings" s/Bool
+            "prefix.sighting.update-settings" s/Bool
             "prefix.sighting.timeout" s/Num}
            (sut/es-store-impl-properties "prefix." "sighting")))))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #https://github.com/threatgrid/iroh/issues/4220

Updating an existing field mapping with `include_in_all` does not make the mapping update fail like any other update of existing field mapping. We need to disable it until ES7 migration, and have a simple control on this.
This PR enable disable mapping/setting update directly from the properties.
The default value is false for a better control on the indices life cycle.

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<a name="ops">[§](#ops)</a> Ops
===============================

The auto setting/mapping update at CTIA startup can now be turned on/off directly from the properties.
The default value is `false`.